### PR TITLE
change spec to test for session and cart helper method

### DIFF
--- a/spec/views/products_index_spec.rb
+++ b/spec/views/products_index_spec.rb
@@ -1,8 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe "products/index", :type => :view do
+  before do
+    controller.singleton_class.class_eval do
+      protected
+        def cart
+          session[:cart]
+        end
+        helper_method :cart
+    end
+  end
+
   it "shows everything in the cart" do
-    assign(:cart, ['apples', 'bananas', 'pears'])
+    session[:cart] = ['apples', 'bananas', 'pears']
     render
     expect(rendered).to include 'apples'
     expect(rendered).to include 'bananas'


### PR DESCRIPTION
A bit of a drastic change to the view spec. The issue is as described in #9 
The spec is specifically testing for some sort of access to an instance variable `@cart` at some point be it in the `cart` helper method or controller or view. This is not consistent with the approach set forth in the Readme of us defining the `cart` helper method to get/set the products in the session. and then using that method to display in the view. This would also be consistent with how we use `current_user` in the layouts or views...

Testing helper methods from application_controller and session things seems to be really tricky with Rspec, definitely with view tests. https://github.com/rspec/rspec-rails/issues/119

So the only feasible way to properly test this seems to be based on the relish docs [here](https://www.relishapp.com/rspec/rspec-rails/v/2-1/docs/view-specs/view-spec#spec-with-view-that-accesses-helper-method-helpers)

I'll make a pull request to change the solution as well to better align with this approach. Hoping this is the right call!
